### PR TITLE
Bump `laravel/framework` from `v12.17.0` to `v12.18.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/filesystem": "~0.1.1",
         "ghostwriter/json": "~3.0.0",
         "ghostwriter/shell": "~0.1.0",
-        "laravel/framework": "~12.17.0",
+        "laravel/framework": "~12.18.0",
         "livewire/livewire": "~3.6.3",
         "nikic/php-parser": "~5.5.0"
     },
@@ -57,7 +57,7 @@
         "livewire/flux": "@stable || ~2.1.6",
         "mockery/mockery": "~1.6.12",
         "orchestra/testbench": "@stable || ~10.4.0",
-        "phpunit/phpunit": "~12.1.6",
+        "phpunit/phpunit": "~12.2.2",
         "symfony/var-dumper": "~7.3.0",
         "vimeo/psalm": "~6.12.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38b49e6c449fe80629c73d1c6681222f",
+    "content-hash": "08b0505d11666723875ce887f0773f33",
     "packages": [
         {
             "name": "brick/math",
@@ -8058,12 +8058,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "0c6a7ac024282d4ec0eedf61ad6df4589a94e172"
+                "reference": "80e793697d7129e2bc324cd28805ea04e7ff6592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0c6a7ac024282d4ec0eedf61ad6df4589a94e172",
-                "reference": "0c6a7ac024282d4ec0eedf61ad6df4589a94e172",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/80e793697d7129e2bc324cd28805ea04e7ff6592",
+                "reference": "80e793697d7129e2bc324cd28805ea04e7ff6592",
                 "shasum": ""
             },
             "require": {
@@ -8206,7 +8206,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-11T15:48:08+00:00"
+            "time": "2025-06-16T16:29:01+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -10490,16 +10490,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.1.6",
+            "version": "12.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2fdf0056c673c8f0f1eed00030be5f8243c1e6e0"
+                "reference": "19e25c2da3f8071a683ee1e445b0e24bba25de61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2fdf0056c673c8f0f1eed00030be5f8243c1e6e0",
-                "reference": "2fdf0056c673c8f0f1eed00030be5f8243c1e6e0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/19e25c2da3f8071a683ee1e445b0e24bba25de61",
+                "reference": "19e25c2da3f8071a683ee1e445b0e24bba25de61",
                 "shasum": ""
             },
             "require": {
@@ -10513,7 +10513,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.2.1",
+                "phpunit/php-code-coverage": "^12.3.0",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -10521,7 +10521,7 @@
                 "sebastian/cli-parser": "^4.0.0",
                 "sebastian/comparator": "^7.0.1",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.1",
+                "sebastian/environment": "^8.0.2",
                 "sebastian/exporter": "^7.0.0",
                 "sebastian/global-state": "^8.0.0",
                 "sebastian/object-enumerator": "^7.0.0",
@@ -10535,7 +10535,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.1-dev"
+                    "dev-main": "12.2-dev"
                 }
             },
             "autoload": {
@@ -10567,7 +10567,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.1.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.2.2"
             },
             "funding": [
                 {
@@ -10591,7 +10591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T12:36:31+00:00"
+            "time": "2025-06-13T05:49:28+00:00"
         },
         {
             "name": "psy/psysh",


### PR DESCRIPTION
Bumps `laravel/framework` from `v12.17.0` to `v12.18.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`