### PR TITLE
Bump `livewire/flux` from `v2.2.2` to `v2.2.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "infection/infection": "@stable || ~0.30.2",
-        "livewire/flux": "@stable || ~2.2.2",
+        "livewire/flux": "@stable || ~2.2.3",
         "mockery/mockery": "~1.6.12",
         "orchestra/testbench": "~10.4.0 || @stable",
         "phpunit/phpunit": "~12.2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25cf4dae4e227c6369bf4dfb2f091fe7",
+    "content-hash": "8798f72b65347b1a2d033e59c62ef0b5",
     "packages": [
         {
             "name": "brick/math",
@@ -8898,16 +8898,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.2.2",
+            "version": "v2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "a995f9513b9eb48b05c8431fe881efa4c6219513"
+                "reference": "0fb4c0b78eac393ad3a19a387af193573c310371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/a995f9513b9eb48b05c8431fe881efa4c6219513",
-                "reference": "a995f9513b9eb48b05c8431fe881efa4c6219513",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/0fb4c0b78eac393ad3a19a387af193573c310371",
+                "reference": "0fb4c0b78eac393ad3a19a387af193573c310371",
                 "shasum": ""
             },
             "require": {
@@ -8955,9 +8955,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.2.2"
+                "source": "https://github.com/livewire/flux/tree/v2.2.3"
             },
-            "time": "2025-07-08T07:13:42+00:00"
+            "time": "2025-07-11T00:25:51+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Bumps `livewire/flux` from `v2.2.2` to `v2.2.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`