### PR TITLE
Bump `livewire/flux` from `v2.2.6` to `v2.3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "~2.2.6",
+        "livewire/flux": "~2.3.0",
         "mockery/mockery": "~1.6.12",
         "orchestra/testbench": "~10.6.0",
         "phpunit/phpunit": "~12.3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c8bc909564d9c35cb2c1e2ff586953b",
+    "content-hash": "1a73307db39f25d7c09fb89332e6ab78",
     "packages": [
         {
             "name": "brick/math",
@@ -7766,16 +7766,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.2.6",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "a0e8f33a5cd54ead4d8e27721961425ccbae2e33"
+                "reference": "83559c48eb929aa2aa33e351e76b501467111e9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/a0e8f33a5cd54ead4d8e27721961425ccbae2e33",
-                "reference": "a0e8f33a5cd54ead4d8e27721961425ccbae2e33",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/83559c48eb929aa2aa33e351e76b501467111e9e",
+                "reference": "83559c48eb929aa2aa33e351e76b501467111e9e",
                 "shasum": ""
             },
             "require": {
@@ -7826,9 +7826,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.2.6"
+                "source": "https://github.com/livewire/flux/tree/v2.3.0"
             },
-            "time": "2025-08-27T02:05:01+00:00"
+            "time": "2025-09-03T21:42:14+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Bumps `livewire/flux` from `v2.2.6` to `v2.3.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`