### PR TITLE
Bump `livewire/flux` from `v2.3.0` to `v2.3.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "~2.3.0",
+        "livewire/flux": "~2.3.1",
         "mockery/mockery": "~1.6.12",
         "orchestra/testbench": "~10.6.0",
         "phpunit/phpunit": "~12.3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e33c10894fd2dec7e2a78e61a3b72d31",
+    "content-hash": "50bd9dfa06593c622f8fdd8e6a645370",
     "packages": [
         {
             "name": "brick/math",
@@ -7766,16 +7766,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.3.0",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "83559c48eb929aa2aa33e351e76b501467111e9e"
+                "reference": "d76c702806f48b75427226a81ffdbfb1d2b1b47d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/83559c48eb929aa2aa33e351e76b501467111e9e",
-                "reference": "83559c48eb929aa2aa33e351e76b501467111e9e",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/d76c702806f48b75427226a81ffdbfb1d2b1b47d",
+                "reference": "d76c702806f48b75427226a81ffdbfb1d2b1b47d",
                 "shasum": ""
             },
             "require": {
@@ -7826,9 +7826,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.3.0"
+                "source": "https://github.com/livewire/flux/tree/v2.3.1"
             },
-            "time": "2025-09-03T21:42:14+00:00"
+            "time": "2025-09-05T03:49:53+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Bumps `livewire/flux` from `v2.3.0` to `v2.3.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`