### PR TITLE
Bump `livewire/flux` from `v2.3.1` to `v2.3.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "~2.3.1",
+        "livewire/flux": "~2.3.2",
         "mockery/mockery": "~1.6.12",
         "orchestra/testbench": "~10.6.0",
         "phpunit/phpunit": "~12.3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50bd9dfa06593c622f8fdd8e6a645370",
+    "content-hash": "9454682d487a29ca21b902c6b6f0c6e6",
     "packages": [
         {
             "name": "brick/math",
@@ -7767,16 +7767,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.3.1",
+            "version": "v2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "d76c702806f48b75427226a81ffdbfb1d2b1b47d"
+                "reference": "e0704b125d5f9544aa32e0cfccb11baaf44d77a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/d76c702806f48b75427226a81ffdbfb1d2b1b47d",
-                "reference": "d76c702806f48b75427226a81ffdbfb1d2b1b47d",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/e0704b125d5f9544aa32e0cfccb11baaf44d77a0",
+                "reference": "e0704b125d5f9544aa32e0cfccb11baaf44d77a0",
                 "shasum": ""
             },
             "require": {
@@ -7827,9 +7827,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.3.1"
+                "source": "https://github.com/livewire/flux/tree/v2.3.2"
             },
-            "time": "2025-09-05T03:49:53+00:00"
+            "time": "2025-09-08T01:11:34+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Bumps `livewire/flux` from `v2.3.1` to `v2.3.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`