### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#dcab526`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7155,12 +7155,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "0da51e2883ffa2ae574ca34c5a57160efcd884e4"
+                "reference": "dcab5268cfe19e68a01cd50576dae7e810f3a589"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0da51e2883ffa2ae574ca34c5a57160efcd884e4",
-                "reference": "0da51e2883ffa2ae574ca34c5a57160efcd884e4",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/dcab5268cfe19e68a01cd50576dae7e810f3a589",
+                "reference": "dcab5268cfe19e68a01cd50576dae7e810f3a589",
                 "shasum": ""
             },
             "require": {
@@ -7210,7 +7210,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.10",
+                "phpunit/phpunit": "~12.3.11",
                 "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
@@ -7317,7 +7317,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T19:21:11+00:00"
+            "time": "2025-09-14T07:11:03+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#0da51e2` to `dev-main#dcab526`.

This pull request changes the following file(s): 

- Update `composer.lock`