### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#e36feb1`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7155,12 +7155,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "dcab5268cfe19e68a01cd50576dae7e810f3a589"
+                "reference": "e36feb1383bc8bb3c86c9ffefa3a39c150bab091"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/dcab5268cfe19e68a01cd50576dae7e810f3a589",
-                "reference": "dcab5268cfe19e68a01cd50576dae7e810f3a589",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e36feb1383bc8bb3c86c9ffefa3a39c150bab091",
+                "reference": "e36feb1383bc8bb3c86c9ffefa3a39c150bab091",
                 "shasum": ""
             },
             "require": {
@@ -7215,17 +7215,17 @@
             },
             "default-branch": true,
             "bin": [
-                "tools/phar/composer-normalize.phar",
-                "tools/phar/composer-require-checker.phar",
-                "tools/phar/composer-unused.phar",
-                "tools/phar/composer.phar",
-                "tools/phar/infection.phar",
-                "tools/phar/phive.phar",
-                "tools/phar/phpactor.phar",
-                "tools/phar/phpbench.phar",
-                "tools/phar/phpdocumentor.phar",
-                "tools/phar/phpunit.phar",
-                "tools/phar/psalm.phar"
+                "tools/phar/composer-normalize",
+                "tools/phar/composer-require-checker",
+                "tools/phar/composer-unused",
+                "tools/phar/composer",
+                "tools/phar/infection",
+                "tools/phar/phive",
+                "tools/phar/phpactor",
+                "tools/phar/phpbench",
+                "tools/phar/phpdocumentor",
+                "tools/phar/phpunit",
+                "tools/phar/psalm"
             ],
             "type": "composer-plugin",
             "extra": {
@@ -7317,7 +7317,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-14T07:11:03+00:00"
+            "time": "2025-09-14T11:57:46+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#dcab526` to `dev-main#e36feb1`.

This pull request changes the following file(s): 

- Update `composer.lock`