### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ea2be7c

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,24 +40,24 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.1.0",
-        "ghostwriter/container": "^5.0.1",
-        "ghostwriter/event-dispatcher": "^5.0.3",
-        "ghostwriter/filesystem": "^0.1.1",
-        "ghostwriter/json": "^3.0.0",
-        "ghostwriter/shell": "^0.1.0",
-        "laravel/framework": "^12.30.1",
-        "livewire/livewire": "^3.6.4",
-        "nikic/php-parser": "^5.6.1"
+        "ghostwriter/case-converter": "~2.1.0",
+        "ghostwriter/container": "~5.0.1",
+        "ghostwriter/event-dispatcher": "~5.0.3",
+        "ghostwriter/filesystem": "~0.1.1",
+        "ghostwriter/json": "~3.0.0",
+        "ghostwriter/shell": "~0.1.0",
+        "laravel/framework": "~12.30.1",
+        "livewire/livewire": "~3.6.4",
+        "nikic/php-parser": "~5.6.1"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "^2.4.0",
-        "mockery/mockery": "^1.6.12",
-        "orchestra/testbench": "^10.6.0",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "livewire/flux": "~2.4.0",
+        "mockery/mockery": "~1.6.12",
+        "orchestra/testbench": "~10.6.0",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f58e5126a408eeadf2f3f7244e3feba9",
+    "content-hash": "ed6ddbd126a0bac4b91e2ec526aef835",
     "packages": [
         {
             "name": "brick/math",
@@ -7227,12 +7227,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ea2be7cf71be411d7350ff61c003867453992ba0",
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0",
                 "shasum": ""
             },
             "require": {
@@ -7389,7 +7389,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T14:31:25+00:00"
+            "time": "2025-09-21T15:43:42+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#62def0c` to `dev-main#ea2be7c`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`