### PR TITLE
Update laravel/framework to version 12.32.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/filesystem": "^0.1.1",
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/shell": "^0.1.0",
-        "laravel/framework": "^12.32.2",
+        "laravel/framework": "^12.32.3",
         "livewire/livewire": "^3.6.4",
         "nikic/php-parser": "^5.6.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4885c67339c89580ca10ca56a7fe26d",
+    "content-hash": "758d98f0dbeec9612c8c24534687da33",
     "packages": [
         {
             "name": "brick/math",
@@ -1430,16 +1430,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.32.2",
+            "version": "v12.32.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "7cdf642d473365fc257a9bec5d8b49d976bc9b0f"
+                "reference": "101f7d1ef000f68ccef15a2529d3e99b0c49a14a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/7cdf642d473365fc257a9bec5d8b49d976bc9b0f",
-                "reference": "7cdf642d473365fc257a9bec5d8b49d976bc9b0f",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/101f7d1ef000f68ccef15a2529d3e99b0c49a14a",
+                "reference": "101f7d1ef000f68ccef15a2529d3e99b0c49a14a",
                 "shasum": ""
             },
             "require": {
@@ -1645,7 +1645,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-30T14:45:00+00:00"
+            "time": "2025-09-30T15:38:34+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
Updates the `laravel/framework` dependency from `v12.32.2` to `12.32.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`