### PR TITLE
Update ghostwriter/coding-standard to version dev-main#560b262

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3659,16 +3659,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.4",
+            "version": "v7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
                 "shasum": ""
             },
             "require": {
@@ -3733,7 +3733,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.4"
+                "source": "https://github.com/symfony/console/tree/v7.3.5"
             },
             "funding": [
                 {
@@ -3753,7 +3753,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-22T15:31:00+00:00"
+            "time": "2025-10-14T15:46:26+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -7154,12 +7154,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "35780161397693f20ffedb783603a444b9e35b67"
+                "reference": "560b26260d25fa97d69f2532d439cec1ea749a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/35780161397693f20ffedb783603a444b9e35b67",
-                "reference": "35780161397693f20ffedb783603a444b9e35b67",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/560b26260d25fa97d69f2532d439cec1ea749a10",
+                "reference": "560b26260d25fa97d69f2532d439cec1ea749a10",
                 "shasum": ""
             },
             "require": {
@@ -7200,7 +7200,7 @@
                 "ghostwriter/result": "^2.0.0",
                 "ghostwriter/shell": "^0.1.0",
                 "php": "~8.4.0 || ~8.5.0",
-                "symfony/console": "^7.3.4"
+                "symfony/console": "^7.3.5"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -7210,7 +7210,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
                 "phpunit/phpunit": "^12.4.1",
-                "symfony/var-dumper": "^7.3.4"
+                "symfony/var-dumper": "^7.3.5"
             },
             "default-branch": true,
             "bin": [
@@ -7316,7 +7316,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-27T14:29:52+00:00"
+            "time": "2025-10-28T11:52:08+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#3578016` to `dev-main#560b262`.

This pull request changes the following file(s): 

- Update `composer.lock`