### PR TITLE
Update ghostwriter/shell to version 0.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/filesystem": "^0.1.1",
         "ghostwriter/json": "^3.0.1",
-        "ghostwriter/shell": "^0.1.0",
+        "ghostwriter/shell": "^0.1.1",
         "laravel/framework": "^12.38.1",
         "livewire/livewire": "^3.6.4",
         "nikic/php-parser": "^5.6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6a6a1b4f7848d992dba5c85a66229f7",
+    "content-hash": "a6dc4d4711cf4e04e964c18935326243",
     "packages": [
         {
             "name": "brick/math",
@@ -906,25 +906,37 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "6a8eae4c14490180b99cdd1260cf767072a6ff83"
+                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/6a8eae4c14490180b99cdd1260cf767072a6ff83",
-                "reference": "6a8eae4c14490180b99cdd1260cf767072a6ff83",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
+                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ext-xdebug": "*",
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/container": "^6.0.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\Shell\\Container\\ShellDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Shell\\": "src"
@@ -932,7 +944,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -950,8 +962,6 @@
                 "shell"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/shell",
-                "forum": "https://github.com/ghostwriter/shell/discussions",
                 "issues": "https://github.com/ghostwriter/shell/issues",
                 "rss": "https://github.com/ghostwriter/shell/releases.atom",
                 "security": "https://github.com/ghostwriter/shell/security/advisories/new",
@@ -963,7 +973,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-22T22:15:04+00:00"
+            "time": "2025-11-25T19:01:49+00:00"
         },
         {
             "name": "graham-campbell/result-type",


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.0` to `0.1.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`