### PR TITLE
Update livewire/flux to version 2.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "^2.6.1",
+        "livewire/flux": "^2.9.0",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.8.0",
         "phpunit/phpunit": "^12.4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b51f8cf5549ccdacfbb1cb0bce8a60c",
+    "content-hash": "b5ee0d60621021684c680e85bfa8c1ff",
     "packages": [
         {
             "name": "brick/math",
@@ -7563,16 +7563,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.6.1",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "227b88db0a02db91666af2303ea6727a3af78c51"
+                "reference": "d961ba5512ecfa38f8b759133ceec0fb295c4e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/227b88db0a02db91666af2303ea6727a3af78c51",
-                "reference": "227b88db0a02db91666af2303ea6727a3af78c51",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/d961ba5512ecfa38f8b759133ceec0fb295c4e16",
+                "reference": "d961ba5512ecfa38f8b759133ceec0fb295c4e16",
                 "shasum": ""
             },
             "require": {
@@ -7623,9 +7623,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.6.1"
+                "source": "https://github.com/livewire/flux/tree/v2.9.0"
             },
-            "time": "2025-10-28T21:12:05+00:00"
+            "time": "2025-11-26T00:32:54+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Updates the `livewire/flux` dependency from `v2.6.1` to `2.9.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`