### PR TITLE
Update livewire/flux to version 2.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "^2.9.0",
+        "livewire/flux": "^2.9.1",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.8.0",
         "phpunit/phpunit": "^12.4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00f8c50f482f299a6547ab19c00342b8",
+    "content-hash": "98bac3b49e90b44d98385381df330566",
     "packages": [
         {
             "name": "brick/math",
@@ -7567,16 +7567,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.9.0",
+            "version": "v2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "d961ba5512ecfa38f8b759133ceec0fb295c4e16"
+                "reference": "041cdd07c74508fb2884d4614ee968c8f51765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/d961ba5512ecfa38f8b759133ceec0fb295c4e16",
-                "reference": "d961ba5512ecfa38f8b759133ceec0fb295c4e16",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/041cdd07c74508fb2884d4614ee968c8f51765e7",
+                "reference": "041cdd07c74508fb2884d4614ee968c8f51765e7",
                 "shasum": ""
             },
             "require": {
@@ -7627,9 +7627,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.9.0"
+                "source": "https://github.com/livewire/flux/tree/v2.9.1"
             },
-            "time": "2025-11-26T00:32:54+00:00"
+            "time": "2025-12-01T23:27:11+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Updates the `livewire/flux` dependency from `v2.9.0` to `2.9.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`