### PR TITLE
Update livewire/flux to version 2.9.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "livewire/flux": "^2.9.1",
+        "livewire/flux": "^2.9.2",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.8.0",
         "phpunit/phpunit": "^12.4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2120ed429eed5c3caec7b897d40fb268",
+    "content-hash": "7a49575cfa6894326071022bbb522cd2",
     "packages": [
         {
             "name": "brick/math",
@@ -7567,16 +7567,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.9.1",
+            "version": "v2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "041cdd07c74508fb2884d4614ee968c8f51765e7"
+                "reference": "6572847f70a18e7cf136bb31201d4064f5c8ade1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/041cdd07c74508fb2884d4614ee968c8f51765e7",
-                "reference": "041cdd07c74508fb2884d4614ee968c8f51765e7",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/6572847f70a18e7cf136bb31201d4064f5c8ade1",
+                "reference": "6572847f70a18e7cf136bb31201d4064f5c8ade1",
                 "shasum": ""
             },
             "require": {
@@ -7627,9 +7627,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.9.1"
+                "source": "https://github.com/livewire/flux/tree/v2.9.2"
             },
-            "time": "2025-12-01T23:27:11+00:00"
+            "time": "2025-12-04T17:09:39+00:00"
         },
         {
             "name": "marc-mabe/php-enum",


### PR DESCRIPTION
Updates the `livewire/flux` dependency from `v2.9.1` to `2.9.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`