### PR TITLE
Update laravel/framework to version 12.47.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "ghostwriter/json": "^3.0.1",
         "ghostwriter/shell": "^0.1.1",
-        "laravel/framework": "^12.46.0",
+        "laravel/framework": "^12.47.0",
         "livewire/livewire": "^3.7.3",
         "nikic/php-parser": "^5.7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25035291a1345b4ad277fb1ae1767e40",
+    "content-hash": "93790b67fb287662c9e78c8cf2809562",
     "packages": [
         {
             "name": "brick/math",
@@ -1471,16 +1471,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.46.0",
+            "version": "v12.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "9dcff48d25a632c1fadb713024c952fec489c4ae"
+                "reference": "ab8114c2e78f32e64eb238fc4b495bea3f8b80ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/9dcff48d25a632c1fadb713024c952fec489c4ae",
-                "reference": "9dcff48d25a632c1fadb713024c952fec489c4ae",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ab8114c2e78f32e64eb238fc4b495bea3f8b80ec",
+                "reference": "ab8114c2e78f32e64eb238fc4b495bea3f8b80ec",
                 "shasum": ""
             },
             "require": {
@@ -1689,7 +1689,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-01-07T23:26:53+00:00"
+            "time": "2026-01-13T15:29:06+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
Updates the `laravel/framework` dependency from `v12.46.0` to `12.47.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`