### PR TITLE
Update livewire/flux to version 2.13.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/json": "^3.0.1",
         "ghostwriter/shell": "^0.1.4",
         "laravel/framework": "^13.3.0",
-        "livewire/flux": "^2.13.1",
+        "livewire/flux": "^2.13.2",
         "livewire/livewire": "^4.2.3",
         "nikic/php-parser": "^5.7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6786f862be641a87673327fe68f09aa8",
+    "content-hash": "7fb2ae84f95d66ce5e800a38c33a77d6",
     "packages": [
         {
             "name": "brick/math",
@@ -2405,16 +2405,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.13.1",
+            "version": "v2.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "5bee3d50ea8382e178d2b10a3412a82e6ecfb4a3"
+                "reference": "4dbf3c4fdb936a66e082495ebd26c0f3193fd72c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/5bee3d50ea8382e178d2b10a3412a82e6ecfb4a3",
-                "reference": "5bee3d50ea8382e178d2b10a3412a82e6ecfb4a3",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/4dbf3c4fdb936a66e082495ebd26c0f3193fd72c",
+                "reference": "4dbf3c4fdb936a66e082495ebd26c0f3193fd72c",
                 "shasum": ""
             },
             "require": {
@@ -2465,9 +2465,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.13.1"
+                "source": "https://github.com/livewire/flux/tree/v2.13.2"
             },
-            "time": "2026-03-26T00:02:01+00:00"
+            "time": "2026-03-31T20:25:36+00:00"
         },
         {
             "name": "livewire/livewire",


### PR DESCRIPTION
Updates the `livewire/flux` dependency from `v2.13.1` to `2.13.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`