### PR TITLE
Update livewire/flux to version 2.14.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/shell": "^0.1.5",
         "laravel/framework": "^13.6.0",
-        "livewire/flux": "^2.13.2",
+        "livewire/flux": "^2.14.0",
         "livewire/livewire": "^4.2.4",
         "nikic/php-parser": "^5.7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8d75104afb9880882d0845702a2416d",
+    "content-hash": "ca38ba8f040d3df0e82902209f57f9b8",
     "packages": [
         {
             "name": "brick/math",
@@ -2436,16 +2436,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.13.2",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "4dbf3c4fdb936a66e082495ebd26c0f3193fd72c"
+                "reference": "2b4c7f106911e00da057109da4220375ae951bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/4dbf3c4fdb936a66e082495ebd26c0f3193fd72c",
-                "reference": "4dbf3c4fdb936a66e082495ebd26c0f3193fd72c",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/2b4c7f106911e00da057109da4220375ae951bbb",
+                "reference": "2b4c7f106911e00da057109da4220375ae951bbb",
                 "shasum": ""
             },
             "require": {
@@ -2496,9 +2496,9 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.13.2"
+                "source": "https://github.com/livewire/flux/tree/v2.14.0"
             },
-            "time": "2026-03-31T20:25:36+00:00"
+            "time": "2026-04-23T11:52:28+00:00"
         },
         {
             "name": "livewire/livewire",


### PR DESCRIPTION
Updates the `livewire/flux` dependency from `v2.13.2` to `2.14.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`