### PR TITLE
Update `laravel/framework` to version `13.14.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/shell": "^0.1.5",
-        "laravel/framework": "^13.13.0",
+        "laravel/framework": "^13.14.0",
         "livewire/flux": "^2.14.1",
         "livewire/livewire": "^4.3.1",
         "nikic/php-parser": "^5.7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69a682c2860398ddb1b363cf4e33090f",
+    "content-hash": "585e0641ab6335b2c68a584d82e78cca",
     "packages": [
         {
             "name": "brick/math",
@@ -1544,16 +1544,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.13.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2"
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e60b1c817a9ef7da319e4007de6cfda5301a58c0",
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0",
                 "shasum": ""
             },
             "require": {
@@ -1764,7 +1764,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-02T14:28:17+00:00"
+            "time": "2026-06-04T18:46:35+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
Updates the [`laravel/framework`](https://packagist.org/packages/laravel/framework) dependency from `v13.13.0` to `13.14.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`